### PR TITLE
Enable responsive mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ import Vimeo from '@u-wave/react-vimeo';
 | showTitle | bool | true | Show the title on the video. |
 | muted | bool | false | Starts in a muted state to help with autoplay |
 | background | bool | false | Starts in a background state with no controls to help with autoplay |
+| responsive | bool | false | Enable responsive mode and resize according to parent element (experimental) |
 | onReady | function |  | Sent when the Vimeo player API has loaded. Receives the Vimeo player object in the first parameter. |
 | onError | function |  | Sent when the player triggers an error. |
 | onPlay | function |  | Triggered when the video plays. |

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/u-wave/react-vimeo#readme",
   "dependencies": {
-    "@vimeo/player": "^2.6.1",
+    "@vimeo/player": "^2.9.1",
     "prop-types": "^15.6.1"
   },
   "peerDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -43,6 +43,7 @@ class Vimeo extends React.Component {
       title: this.props.showTitle,
       muted: this.props.muted,
       background: this.props.background,
+      responsive: this.props.responsive,
     };
     /* eslint-enable react/destructuring-assignment */
   }
@@ -251,6 +252,11 @@ if (process.env.NODE_ENV !== 'production') {
      */
     background: PropTypes.bool,
 
+    /**
+     * Enable responsive mode and resize according to parent element (experimental)
+     */
+    responsive: PropTypes.bool,
+
     // Events
     /* eslint-disable react/no-unused-prop-types */
 
@@ -330,6 +336,7 @@ Vimeo.defaultProps = {
   showTitle: true,
   muted: false,
   background: false,
+  responsive: false,
 };
 
 export default Vimeo;


### PR DESCRIPTION
In the latest version of @vimeo/player.js there is an experimental responsive mode. The iframe is resized according to the parent element.

#add responsive mode to props
#bump @vimeo/player.js version