### PR TITLE
Call `setCurrentTime()` after a new video has loaded.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -90,7 +90,8 @@ class Vimeo extends React.Component {
             const { start } = this.props;
             const loaded = player.loadVideo(value);
             // Set the start time only when loading a new video.
-            // It seems like this has to be done after the video has loaded, else it just starts at the beginning!
+            // It seems like this has to be done after the video has loaded, else it just starts at
+            // the beginning!
             if (typeof start === 'number') {
               loaded.then(() => {
                 player.setCurrentTime(start);

--- a/src/index.js
+++ b/src/index.js
@@ -88,10 +88,13 @@ class Vimeo extends React.Component {
         case 'video':
           if (value) {
             const { start } = this.props;
-            player.loadVideo(value);
+            const loaded = player.loadVideo(value);
             // Set the start time only when loading a new video.
+            // It seems like this has to be done after the video has loaded, else it just starts at the beginning!
             if (typeof start === 'number') {
-              player.setCurrentTime(start);
+              loaded.then(() => {
+                player.setCurrentTime(start);
+              });
             }
           } else {
             player.unload();

--- a/test/util/createVimeo.js
+++ b/test/util/createVimeo.js
@@ -4,18 +4,20 @@ import proxyquire from 'proxyquire';
 export default function createVimeo() {
   let isPaused = true;
 
+  const createPromiseSpy = () => createSpy().andCall(() => Promise.resolve());
+
   const playerMock = {
     on: createSpy(),
     ready() {
       return Promise.resolve();
     },
-    setVolume: createSpy(),
-    setCurrentTime: createSpy(),
-    setAutopause: createSpy(),
-    setColor: createSpy(),
-    setLoop: createSpy(),
-    loadVideo: createSpy(),
-    unload: createSpy(),
+    setVolume: createPromiseSpy(),
+    setCurrentTime: createPromiseSpy(),
+    setAutopause: createPromiseSpy(),
+    setColor: createPromiseSpy(),
+    setLoop: createPromiseSpy(),
+    loadVideo: createPromiseSpy(),
+    unload: createPromiseSpy(),
     play: createSpy().andCall(() => {
       isPaused = false;
     }),


### PR DESCRIPTION
Fixes #68

Apparently doing `setCurrentTime()` immediately is fine for the initial
load, but not when starting a new video.