### PR TITLE
Call `onError()` if initial load fails

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -122,12 +122,18 @@ class Vimeo extends React.Component {
       });
     });
 
-    const { onReady } = this.props;
-    if (onReady) {
-      this.player.ready().then(() => {
+    const { onError, onReady } = this.props;
+    this.player.ready().then(() => {
+      if (onReady) {
         onReady(this.player);
-      });
-    }
+      }
+    }, (err) => {
+      if (onError) {
+        onError(err);
+      } else {
+        throw err;
+      }
+    });
 
     if (typeof start === 'number') {
       this.player.setCurrentTime(start);

--- a/test/test.js
+++ b/test/test.js
@@ -31,6 +31,20 @@ describe('Vimeo', () => {
     expect(onReady.calls[0].arguments[0]).toBe(playerMock);
   });
 
+  it('should all onError when `ready()` fails', async () => {
+    const onError = createSpy();
+    const { sdkMock } = render({
+      video: 404,
+      shouldFail: true,
+      onError,
+    });
+    await Promise.resolve();
+    expect(sdkMock).toHaveBeenCalled();
+    expect(sdkMock.calls[0].arguments[1]).toMatch({ id: 404 });
+    expect(onError).toHaveBeenCalled();
+    expect(onError.calls[0].arguments[0]).toEqual(new Error('artificial failure'));
+  });
+
   it('should load a different video when "video" prop changes', async () => {
     const { sdkMock, playerMock, rerender } = render({
       video: 169408731,

--- a/test/test.js
+++ b/test/test.js
@@ -20,18 +20,19 @@ describe('Vimeo', () => {
 
   it('should create a Vimeo player when mounted', async () => {
     const onReady = createSpy();
-    const { sdkMock, playerMock } = await render({
+    const { sdkMock, playerMock } = render({
       video: 169408731,
       onReady,
     });
     expect(sdkMock).toHaveBeenCalled();
     expect(sdkMock.calls[0].arguments[1]).toMatch({ id: 169408731 });
+    await playerMock.ready();
     expect(onReady).toHaveBeenCalled();
     expect(onReady.calls[0].arguments[0]).toBe(playerMock);
   });
 
   it('should load a different video when "video" prop changes', async () => {
-    const { sdkMock, playerMock, rerender } = await render({
+    const { sdkMock, playerMock, rerender } = render({
       video: 169408731,
     });
     expect(sdkMock).toHaveBeenCalled();
@@ -44,7 +45,7 @@ describe('Vimeo', () => {
   });
 
   it('should pause the video using the "paused" prop', async () => {
-    const { playerMock, rerender } = await render({
+    const { playerMock, rerender } = render({
       video: 169408731,
       autoplay: true,
     });
@@ -61,7 +62,7 @@ describe('Vimeo', () => {
   });
 
   it('should set the volume using the "volume" prop', async () => {
-    const { playerMock, rerender } = await render({
+    const { playerMock, rerender } = render({
       video: 169408731,
       volume: 0.5,
     });
@@ -73,7 +74,7 @@ describe('Vimeo', () => {
   });
 
   it('should set the start time using the "start" prop', async () => {
-    const { playerMock, rerender } = await render({
+    const { playerMock, rerender } = render({
       video: 169408731,
       start: 60,
     });
@@ -88,7 +89,7 @@ describe('Vimeo', () => {
   });
 
   it('should set the player color using the "color" prop', async () => {
-    const { playerMock, sdkMock, rerender } = await render({
+    const { playerMock, sdkMock, rerender } = render({
       video: 169408731,
       color: '#0000ff',
     });
@@ -102,7 +103,7 @@ describe('Vimeo', () => {
   });
 
   it('should set the looping flag using the "loop" prop', async () => {
-    const { playerMock, sdkMock, rerender } = await render({
+    const { playerMock, sdkMock, rerender } = render({
       video: 169408731,
       loop: false,
     });
@@ -116,7 +117,7 @@ describe('Vimeo', () => {
   });
 
   it('should set the iframe width/height using the width/height props', async () => {
-    const { sdkMock, playerMock, rerender } = await render({
+    const { sdkMock, playerMock, rerender } = render({
       video: 169408731,
       width: 640,
       height: 320,
@@ -136,7 +137,7 @@ describe('Vimeo', () => {
   });
 
   it('should destroy player when unmounting', async () => {
-    const { playerMock, unmount } = await render({
+    const { playerMock, unmount } = render({
       video: 169408731,
       width: 640,
       height: 320,

--- a/test/util/createVimeo.js
+++ b/test/util/createVimeo.js
@@ -1,13 +1,15 @@
 import { createSpy } from 'expect';
 import proxyquire from 'proxyquire';
 
-export default function createVimeo() {
+export default function createVimeo({ shouldFail = false } = {}) {
   let isPaused = true;
 
   const playerMock = {
     on: createSpy(),
     ready() {
-      return Promise.resolve();
+      return shouldFail
+        ? Promise.reject(new Error('artificial failure'))
+        : Promise.resolve();
     },
     setVolume: createSpy(),
     setCurrentTime: createSpy(),

--- a/test/util/render.js
+++ b/test/util/render.js
@@ -11,7 +11,9 @@ import createVimeo from './createVimeo';
 Object.assign(global, env);
 
 const render = (initialProps) => {
-  const { Vimeo, sdkMock, playerMock } = createVimeo();
+  const { Vimeo, sdkMock, playerMock } = createVimeo({
+    shouldFail: initialProps.shouldFail,
+  });
 
   let component;
   // Emulate changes to component.props using a container component's state


### PR DESCRIPTION
There doesn't seem to be much we can do if this happens, but we should at least let users know...

Fixes #55