### PR TITLE
Add support for passing the 'dnt' player param as a prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ import Vimeo from '@u-wave/react-vimeo';
 | autoplay | bool | false | Automatically start playback of the video. Note that this won’t work on some devices. |
 | showByline | bool | true | Show the byline on the video. |
 | color | string |  | Specify the color of the video controls. Colors may be overridden by the embed settings of the video. _(Ex: "ef2f9f")_ |
+| dnt | bool | false | Blocks the player from tracking any session data, including all cookies and analytics |
 | controls | bool | true | Hide all elements in the player (play bar, sharing buttons, etc). |
 | loop | bool | false | Play the video again when it reaches the end. |
 | showPortrait | bool | true | Show the portrait on the video. |

--- a/src/index.js
+++ b/src/index.js
@@ -45,6 +45,7 @@ class Vimeo extends React.Component {
       muted: this.props.muted,
       background: this.props.background,
       responsive: this.props.responsive,
+      dnt: this.props.dnt,
     };
     /* eslint-enable react/destructuring-assignment */
   }
@@ -243,6 +244,11 @@ if (process.env.NODE_ENV !== 'production') {
      */
     color: PropTypes.string,
 
+    /**
+     * Blocks the player from tracking any session data, including all cookies and analytics.
+     */
+    dnt: PropTypes.bool,
+
     // Player controls
     /**
      * Hide all elements in the player (play bar, sharing buttons, etc).
@@ -364,6 +370,7 @@ Vimeo.defaultProps = {
   muted: false,
   background: false,
   responsive: false,
+  dnt: false,
 };
 
 export default Vimeo;


### PR DESCRIPTION
This PR adds support for passing the `dnt` prop to disable cookies and tracking.

https://github.com/u-wave/react-vimeo/issues/121