### PR TITLE
add option to seek/set currentTime of the video

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ import Vimeo from '@u-wave/react-vimeo';
 | autopause | bool | true | Pause this video automatically when another one plays. |
 | autoplay | bool | false | Automatically start playback of the video. Note that this won’t work on some devices. |
 | showByline | bool | true | Show the byline on the video. |
+| currentTime | number | | The time in seconds at which to seek/jump the video to. |
 | color | string |  | Specify the color of the video controls. Colors may be overridden by the embed settings of the video. _(Ex: "ef2f9f")_ |
 | dnt | bool | false | Blocks the player from tracking any session data, including all cookies and analytics |
 | controls | bool | true | Hide all elements in the player (play bar, sharing buttons, etc). |

--- a/index.d.ts
+++ b/index.d.ts
@@ -192,6 +192,11 @@ export interface VimeoProps {
   showByline?: boolean
 
   /**
+   * The time in seconds at which to seek/jump the video to.
+   */
+  currentTime?: number
+
+  /**
    * Specify the color of the video controls. Colors may be overridden by the
    * embed settings of the video. _(Ex: "ef2f9f")_
    */

--- a/src/index.js
+++ b/src/index.js
@@ -71,6 +71,9 @@ class Vimeo extends React.Component {
         case 'volume':
           player.setVolume(value);
           break;
+        case "currentTime":
+          player.setCurrentTime(value);
+          break;
         case 'paused':
           player.getPaused().then((paused) => {
             if (value && !paused) {
@@ -237,6 +240,11 @@ if (process.env.NODE_ENV !== 'production') {
      * Show the byline on the video.
      */
     showByline: PropTypes.bool,
+
+    /**
+     * The time in seconds at which to seek/jump the video to.
+     */
+    currentTime: PropTypes.number,
 
     /**
      * Specify the color of the video controls. Colors may be overridden by the


### PR DESCRIPTION
Option to seek/set currentTime of the video for table of contents
- Set the current playback position in seconds
- You can provide an accurate time and the player will attempt to seek to as close to that time as possible. 