### PR TITLE
Speed controls - required by Vimeo now for PRO / Business accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ import Vimeo from '@u-wave/react-vimeo';
 | muted | bool | false | Starts in a muted state to help with autoplay |
 | background | bool | false | Starts in a background state with no controls to help with autoplay |
 | responsive | bool | false | Enable responsive mode and resize according to parent element (experimental) |
+| speed | bool | false | Enable playback rate controls (requires Vimeo PRO / Business account) |
 | onReady | function |  | Sent when the Vimeo player API has loaded. Receives the Vimeo player object in the first parameter. |
 | onError | function |  | Sent when the player triggers an error. |
 | onPlay | function |  | Triggered when the video plays. |

--- a/index.d.ts
+++ b/index.d.ts
@@ -233,6 +233,11 @@ export interface VimeoProps {
   responsive?: boolean
 
   /**
+   * Enable playback rate controls (requires Vimeo PRO / Business account)
+   */
+  speed?: boolean
+
+  /**
    * Sent when the Vimeo player API has loaded.
    * Receives the Vimeo player object in the first parameter.
    */

--- a/src/index.js
+++ b/src/index.js
@@ -377,7 +377,7 @@ Vimeo.defaultProps = {
   background: false,
   responsive: false,
   dnt: false,
-  speed: false
+  speed: false,
 };
 
 export default Vimeo;

--- a/src/index.js
+++ b/src/index.js
@@ -46,6 +46,7 @@ class Vimeo extends React.Component {
       background: this.props.background,
       responsive: this.props.responsive,
       dnt: this.props.dnt,
+      speed: this.props.speed,
     };
     /* eslint-enable react/destructuring-assignment */
   }
@@ -285,6 +286,11 @@ if (process.env.NODE_ENV !== 'production') {
      */
     responsive: PropTypes.bool,
 
+    /**
+     * Enable playback rate controls (requires Vimeo PRO / Business account)
+     */
+    speed: PropTypes.bool,
+
     // Events
     /* eslint-disable react/no-unused-prop-types */
 
@@ -371,6 +377,7 @@ Vimeo.defaultProps = {
   background: false,
   responsive: false,
   dnt: false,
+  speed: false
 };
 
 export default Vimeo;


### PR DESCRIPTION
Hey there, this is a simple prop add for "speed" to match the spec of the [player.js](https://github.com/vimeo/player.js#embed-options) embed options.

This prop is now required for speed controls to be displayed. (It had in the past worked without the embed option present.)