### PR TITLE
Allow more constructor options from props

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ import Vimeo from '@u-wave/react-vimeo';
 | background | bool | false | Starts in a background state with no controls to help with autoplay |
 | responsive | bool | false | Enable responsive mode and resize according to parent element (experimental) |
 | speed | bool | false | Enable playback rate controls (requires Vimeo PRO / Business account) |
+| keyboard | bool | false | Allows for keyboard input to trigger player events. |
+| pip | bool | false | Show the picture-in-picture button in the controlbar and enable the picture-in-picture API. |
+| playsinline | bool | false | Play video inline on mobile devices, to automatically go fullscreen on playback set this parameter to false. |
+| quality | string | false | Vimeo Plus, PRO, and Business members can default an embedded video to a specific quality on desktop. Possible values: `4K`, `2K`, `1080p`, `720p`, `540p`, `360p` and `240p`. |
+| texttrack | string | false | Turn captions/subtitles on for a specific language by default. |
+| transparent | bool | false | The responsive player and transparent background are enabled by default, to disable set this parameter to false. |
 | onReady | function |  | Sent when the Vimeo player API has loaded. Receives the Vimeo player object in the first parameter. |
 | onError | function |  | Sent when the player triggers an error. |
 | onPlay | function |  | Triggered when the video plays. |

--- a/src/index.js
+++ b/src/index.js
@@ -47,6 +47,12 @@ class Vimeo extends React.Component {
       responsive: this.props.responsive,
       dnt: this.props.dnt,
       speed: this.props.speed,
+      keyboard: this.props.keyboard,
+      pip: this.props.pip,
+      playsinline: this.props.playsinline,
+      quality: this.props.quality,
+      texttrack: this.props.texttrack,
+      transparent: this.props.transparent,
     };
     /* eslint-enable react/destructuring-assignment */
   }
@@ -290,6 +296,40 @@ if (process.env.NODE_ENV !== 'production') {
      * Enable playback rate controls (requires Vimeo PRO / Business account)
      */
     speed: PropTypes.bool,
+
+    /**
+     * Allows for keyboard input to trigger player events.
+     */
+    keyboard: PropTypes.bool,
+
+    /**
+     * Show the picture-in-picture button in the controlbar
+     * and enable the picture-in-picture API.
+     */
+    pip: PropTypes.bool,
+
+    /**
+     * Play video inline on mobile devices, to automatically
+     * go fullscreen on playback set this parameter to false.
+     */
+    playsinline: PropTypes.bool,
+
+    /**
+     * Vimeo Plus, PRO, and Business members can default
+     * an embedded video to a specific quality on desktop.
+     */
+    quality: PropTypes.string,
+
+    /**
+     * Turn captions/subtitles on for a specific language by default.
+     */
+    texttrack: PropTypes.string,
+
+    /**
+     * The responsive player and transparent background are enabled
+     * by default, to disable set this parameter to false.
+     */
+    transparent: PropTypes.bool,
 
     // Events
     /* eslint-disable react/no-unused-prop-types */

--- a/src/index.js
+++ b/src/index.js
@@ -418,6 +418,12 @@ Vimeo.defaultProps = {
   responsive: false,
   dnt: false,
   speed: false,
+  keyboard: true,
+  pip: false,
+  playsinline: true,
+  quality: undefined,
+  texttrack: undefined,
+  transparent: true,
 };
 
 export default Vimeo;


### PR DESCRIPTION
This PR adds missing constructor options for Vimeo Player. The latest options are listed here: https://github.com/vimeo/player.js#embed-options