### PR TITLE
build: use pre-workspaces way of installing example

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "name": "react-vimeo-example",
+  "name": "@u-wave/react-vimeo-example",
   "description": "@u-wave/react-vimeo example.",
   "version": "0.0.0-example",
   "scripts": {
@@ -10,11 +10,9 @@
   },
   "dependencies": {
     "@u-wave/react-vimeo": "file:..",
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
-  },
-  "devDependencies": {
     "esbuild": "^0.14.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "serve": "^13.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "tests-only": "cross-env BABEL_ENV=test mocha --require @babel/register test/*.js",
     "tsd": "tsd",
     "docs": "prop-types-table src/index.js | md-insert README.md --header Props -i",
-    "example": "npm run -w example build"
+    "example": "npm run --prefix example build"
   },
   "repository": {
     "type": "git",
@@ -47,6 +47,7 @@
     "@babel/preset-react": "^7.12.10",
     "@babel/register": "^7.12.10",
     "@rollup/plugin-babel": "^5.2.2",
+    "@u-wave/react-vimeo-example": "file:example",
     "cross-env": "^7.0.3",
     "eslint": "^8.2.0",
     "eslint-config-airbnb": "^19.0.0",
@@ -64,12 +65,6 @@
     "react-dom": "^18.0.0",
     "rollup": "^2.35.0",
     "tsd": "^0.20.0"
-  },
-  "workspaces": {
-    "packages": [
-      ".",
-      "./example"
-    ]
   },
   "sideEffects": false
 }


### PR DESCRIPTION
Apparently yarn complains about _dependencies_ having a `workspaces` key even though it's totally valid in other package managers and doesn't affect how the package should be installed 🥲  This way seems to work in recent npm versions however and its still nicely lightweight so it's cool.

Fixes https://github.com/u-wave/react-vimeo/issues/186