### PR TITLE
Fix mistaken event interpretation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ import Vimeo from '@u-wave/react-vimeo';
 | transparent | bool | true | The responsive player and transparent background are enabled by default, to disable set this parameter to false. |
 | onReady | function |  | Sent when the Vimeo player API has loaded. Receives the Vimeo player object in the first parameter. |
 | onError | function |  | Sent when the player triggers an error. |
-| onPlay | function |  | Triggered when the video plays. |
+| onPlay | function |  | Triggered when video playback is initiated. |
+| onPlaying | function |  | Triggered when the video starts playing. |
 | onPause | function |  | Triggered when the video pauses. |
 | onEnd | function |  | Triggered any time the video playback reaches the end. Note: when `loop` is turned on, the ended event will not fire. |
 | onTimeUpdate | function |  | Triggered as the `currentTime` of the video updates. It generally fires every 250ms, but it may vary depending on the browser. |

--- a/index.d.ts
+++ b/index.d.ts
@@ -17,6 +17,8 @@ export type PlayEvent = {
   percent: number
 }
 
+export type PlayingEvent = PlayEvent;
+
 export type PauseEvent = {
   /**
    * The length of the video in seconds.
@@ -286,9 +288,13 @@ export interface VimeoProps {
    */
   onError?: (error: Error) => void
   /**
-   * Triggered when the video plays.
+   * Triggered when video playback is initiated.
    */
   onPlay?: (event: PlayEvent) => void
+  /**
+   * Triggered when the video starts playing.
+   */
+  onPlaying?: (event: PlayingEvent) => void
   /**
    * Triggered when the video pauses.
    */

--- a/src/eventNames.js
+++ b/src/eventNames.js
@@ -1,5 +1,6 @@
 export default {
   play: 'onPlay',
+  playing: 'onPlaying',
   pause: 'onPause',
   ended: 'onEnd',
   timeupdate: 'onTimeUpdate',

--- a/src/index.js
+++ b/src/index.js
@@ -345,9 +345,13 @@ if (process.env.NODE_ENV !== 'production') {
      */
     onError: PropTypes.func,
     /**
-     * Triggered when the video plays.
+     * Triggered when video playback is initiated.
      */
     onPlay: PropTypes.func,
+    /**
+     * Triggered when the video starts playing.
+     */
+    onPlaying: PropTypes.func,
     /**
      * Triggered when the video pauses.
      */

--- a/test/util/createVimeo.js
+++ b/test/util/createVimeo.js
@@ -19,6 +19,7 @@ export default function createVimeo({ shouldFail = false } = {}) {
     setColor: createPromiseSpy(),
     setLoop: createPromiseSpy(),
     loadVideo: createPromiseSpy(),
+    playing: createPromiseSpy(),
     unload: createPromiseSpy(),
     play: createSpy().andCall(() => {
       isPaused = false;


### PR DESCRIPTION
According to `@vimeo/player` [docs](https://www.npmjs.com/package/@vimeo/player) – there's a difference between events: `playing` and `play`, described as follows:

<img width="751" alt="image" src="https://user-images.githubusercontent.com/28493823/187083435-9d794a1c-2f4a-45bd-83f7-6e47ac0f1d53.png">

But the documentation of yours says something else:
<img width="848" alt="image" src="https://user-images.githubusercontent.com/28493823/187083467-db3df535-8284-4a7a-b0f4-5cdb61ebcd99.png">

It's way misleading, because `onPlay` is called only once and it would be much appreciated if it could be handled 😅 