### PR TITLE
Add React 19 to peer dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [16.x, 18.x, 20.x]
-        react-version: [17.x, 18.x, beta]
+        react-version: [17.x, 18.x, 19.x]
         include:
           - node-version: 14.x
             react-version: 16.0.0

--- a/package.json
+++ b/package.json
@@ -33,13 +33,13 @@
   },
   "homepage": "https://github.com/u-wave/react-vimeo#readme",
   "dependencies": {
-    "@types/react": "^17.0.0 || ^18.0.0",
+    "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
     "@types/vimeo__player": "^2.10.0",
     "@vimeo/player": "^2.16.4",
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+    "react": "^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.10",


### PR DESCRIPTION
It appears to just work.

Closes https://github.com/u-wave/react-vimeo/issues/281